### PR TITLE
solc 0.6 compatibility

### DIFF
--- a/src/test.sol
+++ b/src/test.sol
@@ -26,14 +26,9 @@ contract DSTest {
 
     bool public IS_TEST;
     bool public failed;
-    bool SUPPRESS_SETUP_WARNING;  // hack for solc pure restriction warning
 
     constructor() internal {
         IS_TEST = true;
-    }
-
-    function setUp() public {
-        SUPPRESS_SETUP_WARNING = true;  // totally unused by anything
     }
 
     function fail() internal {


### PR DESCRIPTION
functions that are being overridden needs to be given an explicit `virtual` keyword in solc-0.6. But there's no need to have them be present in the first place.