### PR TITLE
Add assert approx and assert false

### DIFF
--- a/src/test.sol
+++ b/src/test.sol
@@ -69,6 +69,20 @@ contract DSTest {
         }
     }
 
+    function assertFalse(bool condition) internal {
+        if (condition) {
+            emit log("Error: Assertion Failed");
+            fail();
+        }
+    }
+
+    function assertFalse(bool condition, string memory err) internal {
+        if (condition) {
+            emit log_named_string("Error", err);
+            assertFalse(condition);
+        }
+    }
+
     function assertEq(address a, address b) internal {
         if (a != b) {
             emit log("Error: a == b not satisfied [address]");


### PR DESCRIPTION
This PR has been opened to add 2 functionalities:

- `assertApproxEq`: allows to do testing with an approximation given as input (to avoid small rounding errors).
- `assertFalse`: The opposite of `assertFalse` for convenience.

It seems there is a duplicate PR for `assertFalse` [here](https://github.com/dapphub/ds-test/pull/22) so we can just merge it and only add the commit for the `assertApproxEq` from this PR or simply just merge this PR 🙂

Thanks for you feedbacks! 