### PR TITLE
fix: correct assertion failure logs

### DIFF
--- a/src/test.sol
+++ b/src/test.sol
@@ -428,8 +428,8 @@ contract DSTest {
     function assertEq(string memory a, string memory b) internal {
         if (keccak256(abi.encodePacked(a)) != keccak256(abi.encodePacked(b))) {
             emit log("Error: a == b not satisfied [string]");
-            emit log_named_string("  Value a", a);
-            emit log_named_string("  Value b", b);
+            emit log_named_string("  Expected", b);
+            emit log_named_string("    Actual", a);
             fail();
         }
     }
@@ -455,8 +455,8 @@ contract DSTest {
     function assertEq0(bytes memory a, bytes memory b) internal {
         if (!checkEq0(a, b)) {
             emit log("Error: a == b not satisfied [bytes]");
-            emit log_named_bytes("  Expected", a);
-            emit log_named_bytes("    Actual", b);
+            emit log_named_bytes("  Expected", b);
+            emit log_named_bytes("    Actual", a);
             fail();
         }
     }


### PR DESCRIPTION
## Motivation

Assertion failure logs are incorrect.

`assertEq0(bytes memory a, bytes memory b)` mixes up `Expected` and `Actual` values.

```solidity
assertEq0(bFun(), hex"ff");
// Expected: 0x00
// Actual: 0xff
```

Additionally, `assertEq(string memory a, string memory b)` uses `Value a` and `Value b` unlike the other `assertEq` functions, which use `Expected` and `Actual`.

```solidity
assertEq(sFun(), "gm");
// Value a: gn
// Value b: gm
```

## Solution

Correct the logs.

```solidity
assertEq0(bFun(), hex"ff");
// Expected: 0xff
// Actual: 0x00
```

```solidity
assertEq(sFun(), "gm");
// Expected: gm
// Actual: gn
```