### PR TITLE
refactor: mark `fail` `virtual`

### DIFF
--- a/src/test.sol
+++ b/src/test.sol
@@ -62,7 +62,7 @@ contract DSTest {
         }
     } 
 
-    function fail() internal {
+    function fail() internal virtual {
         if (hasHEVMContext()) {
             (bool status, ) = HEVM_ADDRESS.call(
                 abi.encodePacked(


### PR DESCRIPTION
## Motivation

Overriding `fail` will allow us to halt a test if a condition is not met.

This will prevent the case when a test continues despite errors, causing a chain reaction that triggers a revert in an external contract, which is confusing.

Closes #29 

## Solution

```solidity
function fail() internal virtual {
```