### PR TITLE
feat: make `fail()` virtual

### DIFF
--- a/src/test.sol
+++ b/src/test.sol
@@ -62,7 +62,7 @@ contract DSTest {
         }
     }
 
-    function fail() internal {
+    function fail() internal virtual {
         if (hasHEVMContext()) {
             (bool status, ) = HEVM_ADDRESS.call(
                 abi.encodePacked(

--- a/src/test.t.sol
+++ b/src/test.t.sol
@@ -306,6 +306,7 @@ contract DemoTest is DSTest {
 
     // --- fail override ---
 
+    // ensure that fail can be overridden
     function fail() internal override {
         super.fail();
     }

--- a/src/test.t.sol
+++ b/src/test.t.sol
@@ -303,4 +303,10 @@ contract DemoTest is DSTest {
     function testFailAssertLeDecimalIntWithMsg() public {
         assertLeDecimal(-1, -2, 18, "msg");
     }
+
+    // --- fail override ---
+
+    function fail() internal override {
+        super.fail();
+    }
 }


### PR DESCRIPTION
Making `fail()` virtual allows us to easily plug in other frameworks. This can be useful if we want to change the behavior for an `assert(false)` statement, which would allow us to easily adapt a given test-setup for use with Echidna or the SMTChecker for formal verification.